### PR TITLE
[SUPERSEDED] FIX Windows conda-forge MKL CI failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+3.7.0 (TBD)
+===========
+
+- Only warn about simultaneous `libomp` and `libiomp` usage on Linux, where the
+  incompatibility is known to cause crashes. This avoids spurious test failures on
+  Windows CI jobs that load both libraries via conda-forge MKL stacks.
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1215,6 +1215,13 @@ class ThreadpoolController:
 
     def _warn_if_incompatible_openmp(self):
         """Raise a warning if llvm-OpenMP and intel-OpenMP are both loaded"""
+        if sys.platform != "linux":
+            # The incompatibility between libomp and libiomp is known to cause
+            # crashes on Linux. On other platforms, conda-forge may expose both
+            # libraries without the same runtime conflict (for instance when
+            # libiomp forwards to libomp on Windows).
+            return
+
         prefixes = [lib_controller.prefix for lib_controller in self.lib_controllers]
         msg = textwrap.dedent(
             """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Superseded by https://github.com/ogrisel/threadpoolctl/pull/12 targeting joblib/threadpoolctl via compare link.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9813b197-af52-4e07-9a2a-bc44019c571b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9813b197-af52-4e07-9a2a-bc44019c571b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

